### PR TITLE
fix: add authorized parties to clerk middleware configuration

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,8 @@
 import { clerkMiddleware } from "@clerk/nextjs/server";
 
-export default clerkMiddleware();
+export default clerkMiddleware({
+	authorizedParties: ["https://prepen.bine.codes", "preview.prepen.bine.codes"],
+});
 
 export const config = {
 	matcher: [

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,7 @@
 import { clerkMiddleware } from "@clerk/nextjs/server";
 
 export default clerkMiddleware({
-	authorizedParties: ["https://prepen.bine.codes", "preview.prepen.bine.codes"],
+	authorizedParties: ["https://prepen.bine.codes", "https://preview.prepen.bine.codes"],
 });
 
 export const config = {


### PR DESCRIPTION
This pull request updates the `middleware.ts` file to enhance security by specifying authorized parties for the `clerkMiddleware`.

* [`middleware.ts`](diffhunk://#diff-3c67eb27b539c61276d7c7cbcdbe15d4b37a6cbf58bf8bc12c1c4d7619c96d1cL3-R5): Added the `authorizedParties` option to the `clerkMiddleware` configuration, restricting access to specific domains (`https://prepen.bine.codes` and `preview.prepen.bine.codes`).